### PR TITLE
ロールバック処理の追加

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -72,7 +72,7 @@ class BookController extends Controller
             DB::transaction(function () use (&$request,&$book) {
                 $book->fill($request->all())->save();
                 Log::info(json_encode($book, JSON_UNESCAPED_UNICODE));
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録内容を修正しました。"], 200);
@@ -94,7 +94,7 @@ class BookController extends Controller
             DB::transaction(function () use (&$book) {
                 Log::info(json_encode($book, JSON_UNESCAPED_UNICODE));
                 $book->delete();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"削除しました。"], 200);

--- a/app/Http/Controllers/LoansController.php
+++ b/app/Http/Controllers/LoansController.php
@@ -35,7 +35,7 @@ class LoansController extends Controller
 
                 Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
                 $loan->save();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録しました。"], 200);
@@ -65,7 +65,7 @@ class LoansController extends Controller
             DB::transaction(function () use (&$request,&$loan) {
                 $loan->fill($request->all())->save();
                 Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録内容を修正しました。"], 200);
@@ -88,7 +88,7 @@ class LoansController extends Controller
             DB::transaction(function () use (&$loan) {
                 Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
                 $loan->delete();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"削除しました。"], 200);

--- a/app/Http/Controllers/LoansController.php
+++ b/app/Http/Controllers/LoansController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\LoanRequest;
 use Exception;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 
 class LoansController extends Controller
 {
@@ -26,17 +27,18 @@ class LoansController extends Controller
     {
 
         try {
+            DB::transaction(function () use (&$request) {
+                Log::info($request->all());
+                $loan = new Loan();
+                // 一気に全部のカラムをセット
+                $loan->fill($request->all());
 
-            Log::info($request->all());
-            $loan = new Loan();
-            // 一気に全部のカラムをセット
-            $loan->fill($request->all());
+                Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
+                $loan->save();
+                throw new \Exception('エラーが出たよ');
+            });
 
-            Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
-
-           if($loan->save()){
-                return response()->json(["message"=>"登録しました。"], 200);
-           }
+            return response()->json(["message"=>"登録しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -44,7 +46,6 @@ class LoansController extends Controller
             return response()->json(["message"=>[$e->getMessage()]]);
 
         }
-
     }
 
     /**
@@ -61,9 +62,13 @@ class LoansController extends Controller
     public function update(LoanRequest $request, Loan $loan)
     {
         try {
+            DB::transaction(function () use (&$request,&$loan) {
+                $loan->fill($request->all())->save();
+                Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
+                throw new \Exception('エラーが出たよ');
+            });
 
-            $loan->fill($request->all())->save();
-            Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
+            return response()->json(["message"=>"登録内容を修正しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -80,11 +85,13 @@ class LoansController extends Controller
     public function destroy(Loan $loan)
     {
         try {
+            DB::transaction(function () use (&$loan) {
+                Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
+                $loan->delete();
+                throw new \Exception('エラーが出たよ');
+            });
 
-            Log::info(json_encode($loan, JSON_UNESCAPED_UNICODE));
-            if($loan->delete()){
-                return response()->json(["message"=>"削除しました。"], 200);
-            }
+            return response()->json(["message"=>"削除しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -92,6 +99,5 @@ class LoansController extends Controller
             return response()->json(["message"=>[$e->getMessage()]]);
 
         }
-
     }
 }

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -65,7 +65,7 @@ class ReviewsController extends Controller
             DB::transaction(function () use (&$request,&$reviews) {
                 $reviews->fill($request->all())->save();
                 Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録内容を修正しました。"], 200);
@@ -88,7 +88,7 @@ class ReviewsController extends Controller
 
                 Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
                 $reviews->delete();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"削除しました。"], 200);

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -5,8 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\Review;
 use Illuminate\Http\Request;
 use App\Http\Requests\ReviewRequest;
-use Exception;
+use Exceptions;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 
 class ReviewsController extends Controller
 {
@@ -26,17 +27,18 @@ class ReviewsController extends Controller
     {
 
         try {
+            DB::transaction(function () use (&$request) {
+                Log::info($request->all());
+                $review = new Review();
+                // 一気に全部のカラムをセット
+                $review->fill($request->all());
 
-            Log::info($request->all());
-            $review = new Review();
-            // 一気に全部のカラムをセット
-            $review->fill($request->all());
+                Log::info(json_encode($review, JSON_UNESCAPED_UNICODE));
+               $review->save();
+            //    throw new \Exception('エラーが出たよ');
+            });
 
-            Log::info(json_encode($review, JSON_UNESCAPED_UNICODE));
-
-           if($review->save()){
-                return response()->json(["message"=>"登録しました。"], 200);
-           }
+            return response()->json(["message"=>"登録しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -44,7 +46,6 @@ class ReviewsController extends Controller
             return response()->json(["message"=>[$e->getMessage()]]);
 
         }
-
     }
 
     /**
@@ -61,9 +62,13 @@ class ReviewsController extends Controller
     public function update(ReviewRequest $request, Review $reviews)
     {
         try {
+            DB::transaction(function () use (&$request,&$reviews) {
+                $reviews->fill($request->all())->save();
+                Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
+                throw new \Exception('エラーが出たよ');
+            });
 
-            $reviews->fill($request->all())->save();
-            Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
+            return response()->json(["message"=>"登録内容を修正しました。"], 200);
 
         }  catch(\Exception $e) {
 
@@ -79,11 +84,14 @@ class ReviewsController extends Controller
     public function destroy(Review $reviews)
     {
         try {
+            DB::transaction(function () use (&$reviews) {
 
-            Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
-            if($reviews->delete()){
-                return response()->json(["message"=>"削除しました。"], 200);
-            }
+                Log::info(json_encode($reviews, JSON_UNESCAPED_UNICODE));
+                $reviews->delete();
+                throw new \Exception('エラーが出たよ');
+            });
+
+            return response()->json(["message"=>"削除しました。"], 200);
 
         } catch(\Exception $e) {
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -35,7 +35,7 @@ class UserController extends Controller
 
                 Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
                 $user->save();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録しました。"], 200);
@@ -67,7 +67,7 @@ class UserController extends Controller
 
                 $user->fill($request->all())->save();
                 Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"登録内容を修正しました。"], 200);
@@ -90,7 +90,7 @@ class UserController extends Controller
             DB::transaction(function () use (&$user) {
                 Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
                 $user->delete();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             });
 
             return response()->json(["message"=>"削除しました。"], 200);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use Exception;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 
 class UserController extends Controller
 {
@@ -26,17 +27,18 @@ class UserController extends Controller
     {
 
         try {
+            DB::transaction(function () use (&$request) {
+                Log::info($request->all());
+                $user = new User();
+                // 一気に全部のカラムをセット
+                $user->fill($request->all());
 
-            Log::info($request->all());
-            $user = new User();
-            // 一気に全部のカラムをセット
-            $user->fill($request->all());
+                Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
+                $user->save();
+                throw new \Exception('エラーが出たよ');
+            });
 
-            Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
-
-           if($user->save()){
-                return response()->json(["message"=>"登録しました。"], 200);
-           }
+            return response()->json(["message"=>"登録しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -44,7 +46,6 @@ class UserController extends Controller
             return response()->json(["message"=>[$e->getMessage()]]);
 
         }
-
     }
 
     /**
@@ -62,9 +63,14 @@ class UserController extends Controller
     {
 
         try {
+            DB::transaction(function () use (&$request,&$user) {
 
-            $user->fill($request->all())->save();
-            Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
+                $user->fill($request->all())->save();
+                Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
+                throw new \Exception('エラーが出たよ');
+            });
+
+            return response()->json(["message"=>"登録内容を修正しました。"], 200);
 
         } catch(\Exception $e) {
 
@@ -81,11 +87,13 @@ class UserController extends Controller
     public function destroy(User $user)
     {
         try {
+            DB::transaction(function () use (&$user) {
+                Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
+                $user->delete();
+                throw new \Exception('エラーが出たよ');
+            });
 
-            Log::info(json_encode($user, JSON_UNESCAPED_UNICODE));
-            if($user->delete()){
-                return response()->json(["message"=>"削除しました。"], 200);
-            }
+            return response()->json(["message"=>"削除しました。"], 200);
 
         } catch(\Exception $e) {
 

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -39,6 +39,7 @@ class Review extends Model
                 $recommend_reviews->rating = $reviews->rating;
                 $recommend_reviews->comment = $reviews->comment;
                 $recommend_reviews->save();
+                throw new \Exception('エラーが出たよ');
             }
         });
     }

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -39,7 +39,7 @@ class Review extends Model
                 $recommend_reviews->rating = $reviews->rating;
                 $recommend_reviews->comment = $reviews->comment;
                 $recommend_reviews->save();
-                throw new \Exception('エラーが出たよ');
+                // throw new \Exception('エラーが出たよ');
             }
         });
     }


### PR DESCRIPTION
**ロールバックの処理を追加し、動作確認を行いましたのでレビューをお願いします。**

全てのコントローラーでエビデンスを取ると量が多くなってしまうので

> ・テーブルAにデータ登録
> ・上記に連動し、テーブルBにデータ登録
> →テーブルBの登録処理中に throw Exception

この観点でのエビデンスのみ添付します。

****実行前
![スクリーンショット 2024-01-26 1 32 49](https://github.com/visionary-japan/laravel-api-learning/assets/125981166/53639131-4003-4b4f-95a1-cc0724e5f444)

**実行後のreviewsテーブル**
![スクリーンショット 2024-01-26 1 44 39](https://github.com/visionary-japan/laravel-api-learning/assets/125981166/cbc84059-112a-4af4-ac80-e42c0cf2845a)

**実行後のrecommend_reviewsテーブル**
![スクリーンショット 2024-01-26 1 44 53](https://github.com/visionary-japan/laravel-api-learning/assets/125981166/c03cc03b-0b7e-488a-9055-d9b3d4a590a7)
